### PR TITLE
Implement FAISS GPU support

### DIFF
--- a/scHPL/faissKNeighbors.py
+++ b/scHPL/faissKNeighbors.py
@@ -9,17 +9,23 @@ import faiss
 import numpy as np
 
 class FaissKNeighbors:
-    def __init__(self, k=50, gpu=None):
+    def __init__(self, k=50, gpu=None, compress=False):
         self.index = None
         self.y = None
         self.k = k
         self.gpu = gpu
+        self.compress = compress
 
     def fit(self, X, y):
         self.index = faiss.IndexFlatL2(X.shape[1])
+
+        if self.compress:
+            self.index = faiss.IndexIVFPQ(self.index, X.shape[1], 100, 16, 8)
+
         if self.gpu is not None:
             res = faiss.StandardGpuResources()
             self.index = faiss.index_cpu_to_gpu(res, self.gpu, self.index)
+
         self.index.add(X.astype(np.float32))
         self.y = y
 

--- a/scHPL/faissKNeighbors.py
+++ b/scHPL/faissKNeighbors.py
@@ -23,11 +23,14 @@ class FaissKNeighbors:
             self.index = faiss.IndexIVFPQ(self.index, X.shape[1], 100, 16, 8)
 
         if self.gpu is not None:
-            res = faiss.StandardGpuResources()
-            self.index = faiss.index_cpu_to_gpu(res, self.gpu, self.index)
+            self.to_gpu(self.gpu)
 
         self.index.add(X.astype(np.float32))
         self.y = y
+
+    def to_gpu(self, gpu):
+        res = faiss.StandardGpuResources()
+        self.index = faiss.index_cpu_to_gpu(res, gpu, self.index)
 
     def predict(self, X):
         distances, indices = self.index.search(X.astype(np.float32), k=self.k)

--- a/scHPL/faissKNeighbors.py
+++ b/scHPL/faissKNeighbors.py
@@ -9,19 +9,14 @@ import faiss
 import numpy as np
 
 class FaissKNeighbors:
-    def __init__(self, k=50, gpu=None, compress=False):
+    def __init__(self, k=50, gpu=None):
         self.index = None
         self.y = None
         self.k = k
         self.gpu = gpu
-        self.compress = compress
 
     def fit(self, X, y):
         self.index = faiss.IndexFlatL2(X.shape[1])
-
-        if self.compress:
-            self.index = faiss.IndexIVFPQ(self.index, X.shape[1], 100, 16, 8)
-
         if self.gpu is not None:
             self.to_gpu(self.gpu)
 

--- a/scHPL/faissKNeighbors.py
+++ b/scHPL/faissKNeighbors.py
@@ -9,13 +9,17 @@ import faiss
 import numpy as np
 
 class FaissKNeighbors:
-    def __init__(self, k=50):
+    def __init__(self, k=50, gpu=None):
         self.index = None
         self.y = None
         self.k = k
+        self.gpu = gpu
 
     def fit(self, X, y):
         self.index = faiss.IndexFlatL2(X.shape[1])
+        if self.gpu is not None:
+            res = faiss.StandardGpuResources()
+            self.index = faiss.index_cpu_to_gpu(res, self.gpu, self.index)
         self.index.add(X.astype(np.float32))
         self.y = y
 

--- a/scHPL/learn.py
+++ b/scHPL/learn.py
@@ -41,8 +41,7 @@ def learn_tree(data: AnnData,
                match_threshold: float = 0.25,
                attach_missing: bool = False,
                print_conf: bool = False,
-               gpu: Optional[int] = None,
-               compress: bool = False
+               gpu: Optional[int] = None
 ):
     
     '''Learn a classification tree based on multiple labeled datasets.
@@ -97,8 +96,6 @@ def learn_tree(data: AnnData,
             Whether to print the confusion matrices during the matching step.
         gpu: int = None
             GPU index to use for the Faiss library (only used when classifier='knn')
-        compress: Boolean = False
-            If 'True', the Faiss index is compressed (only used when classifier='knn')
             
         Returns
         -------
@@ -143,13 +140,13 @@ def learn_tree(data: AnnData,
         if retrain:
             tree = train_tree(data_1, labels_1, tree, classifier, 
                               dimred, useRE, FN, n_neighbors, dynamic_neighbors,
-                              distkNN, gpu=gpu, compress=compress)
+                              distkNN, gpu=gpu)
         else:
             retrain = True 
         
         tree_2 = train_tree(data_2, labels_2, tree_2, classifier, 
                             dimred, useRE, FN, n_neighbors, dynamic_neighbors,
-                            distkNN, gpu=gpu, compress=compress)
+                            distkNN, gpu=gpu)
         
         # Predict labels other dataset
         labels_2_pred,_ = predict_labels(data_2, tree, threshold=rej_threshold)

--- a/scHPL/learn.py
+++ b/scHPL/learn.py
@@ -42,7 +42,8 @@ def learn_tree(data: AnnData,
                attach_missing: bool = False,
                print_conf: bool = False,
                print_tree: bool = True,
-               gpu: Optional[int] = None
+               gpu: Optional[int] = None,
+               compress: bool = False
 ):
     
     '''Learn a classification tree based on multiple labeled datasets.
@@ -99,6 +100,8 @@ def learn_tree(data: AnnData,
             Whether to print the tree during the training.
         gpu: int = None
             GPU index to use for the Faiss library (only used when classifier='knn')
+        compress: Boolean = False
+            If 'True', the Faiss index is compressed (only used when classifier='knn')
             
         Returns
         -------
@@ -144,13 +147,13 @@ def learn_tree(data: AnnData,
         if retrain:
             tree = train_tree(data_1, labels_1, tree, classifier, 
                               dimred, useRE, FN, n_neighbors, dynamic_neighbors,
-                              distkNN, gpu=gpu)
+                              distkNN, gpu=gpu, compress=compress)
         else:
             retrain = True 
         
         tree_2 = train_tree(data_2, labels_2, tree_2, classifier, 
                             dimred, useRE, FN, n_neighbors, dynamic_neighbors,
-                            distkNN, gpu=gpu)
+                            distkNN, gpu=gpu, compress=compress)
         
         # Predict labels other dataset
         labels_2_pred,_ = predict_labels(data_2, tree, threshold=rej_threshold)

--- a/scHPL/learn.py
+++ b/scHPL/learn.py
@@ -18,9 +18,9 @@ from .update import update_tree
 # from update import update_tree
 
 try:
-    from typing import Literal
+    from typing import Literal, Optional
 except ImportError:
-    from typing_extensions import Literal
+    from typing_extensions import Literal, Optional
 
 
 def learn_tree(data: AnnData,
@@ -42,7 +42,7 @@ def learn_tree(data: AnnData,
                attach_missing: bool = False,
                print_conf: bool = False,
                print_tree: bool = True,
-               gpu: int | None = None
+               gpu: Optional[int] = None
 ):
     
     '''Learn a classification tree based on multiple labeled datasets.

--- a/scHPL/learn.py
+++ b/scHPL/learn.py
@@ -9,7 +9,7 @@ import numpy as np
 from anndata import AnnData
 
 from .train import train_tree
-from .utils import TreeNode, create_tree, print_tree as print_tree_func
+from .utils import TreeNode, create_tree, print_tree
 from .predict import predict_labels
 from .update import update_tree
 # from train import train_tree
@@ -41,7 +41,6 @@ def learn_tree(data: AnnData,
                match_threshold: float = 0.25,
                attach_missing: bool = False,
                print_conf: bool = False,
-               print_tree: bool = True,
                gpu: Optional[int] = None,
                compress: bool = False
 ):
@@ -96,8 +95,6 @@ def learn_tree(data: AnnData,
             If 'True' missing nodes are attached to the root node.
         print_conf: Boolean = False
             Whether to print the confusion matrices during the matching step.
-        print_tree: Boolean = True
-            Whether to print the tree during the training.
         gpu: int = None
             GPU index to use for the Faiss library (only used when classifier='knn')
         compress: Boolean = False
@@ -129,9 +126,8 @@ def learn_tree(data: AnnData,
     labels_1 = labels[idx_1]
     data_1 = xx[idx_1]
     
-    if print_tree:
-        print('Starting tree:')
-        print_tree_func(tree)
+    print('Starting tree:')
+    print_tree(tree)
     
     for b in batch_order:
         
@@ -170,9 +166,8 @@ def learn_tree(data: AnnData,
         
         missing_pop.extend(mis_pop)
         
-        if print_tree:
-            print('\nUpdated tree:')
-            print_tree_func(tree, np.unique(labels_2))
+        print('\nUpdated tree:')
+        print_tree(tree, np.unique(labels_2))
         
         #concatenate the two datasets
         data_1 = np.concatenate((data_1, data_2), axis = 0)

--- a/scHPL/predict.py
+++ b/scHPL/predict.py
@@ -7,6 +7,12 @@ Created on Wed Oct 23 14:16:59 2019
 import numpy as np
 from numpy import linalg as LA
 from .utils import TreeNode
+from .faissKNeighbors import FaissKNeighbors
+try:
+    from tqdm import tqdm
+except ImportError:
+    def tqdm(x):
+        return x
 # from utils import TreeNode
 
 def predict_labels(testdata, 
@@ -60,7 +66,7 @@ def predict_labels(testdata,
     
     labels_all = []
     prob_all = np.zeros((np.shape(testdata)[0],1))
-    for idx, testpoint in enumerate(testdata):
+    for idx, testpoint in enumerate(tqdm(testdata)):
         if useRE:   
             if rej_RE[idx]:
                 labels_all.append('Rejected (RE)')

--- a/scHPL/predict.py
+++ b/scHPL/predict.py
@@ -11,7 +11,8 @@ from .utils import TreeNode
 
 def predict_labels(testdata, 
                    tree: TreeNode, 
-                   threshold: float = 0.5):
+                   threshold: float = 0.5,
+                   gpu=None):
     '''Use the trained tree to predict the labels of a new dataset. 
     
         Parameters
@@ -51,6 +52,11 @@ def predict_labels(testdata,
         pca, pcs = tree[0].get_pca()
         testdata = pca.transform(testdata)
         dimred = True
+
+    if (tree[0].classifier and 
+        tree[0].classifier.__class__ == FaissKNeighbors and 
+        gpu is not None):
+        tree[0].classifier.to_gpu(gpu)
     
     labels_all = []
     prob_all = np.zeros((np.shape(testdata)[0],1))

--- a/scHPL/train.py
+++ b/scHPL/train.py
@@ -34,7 +34,8 @@ def train_tree(data,
                FN: float = 0.5, 
                n_neighbors: int = 50,
                dynamic_neighbors: bool = True,
-               distkNN: int = 99):
+               distkNN: int = 99,
+               gpu=None):
     '''Train a hierarchical classifier. 
     
         Parameters
@@ -66,6 +67,8 @@ def train_tree(data,
             cell and it's closest neighbor of the training set. Threshold is 
             set to the distkNN's percentile of distances within the training
             set
+        gpu: int | None = None
+            GPU index to use for the Faiss library (only used when classifier='knn')
 
         
         Returns
@@ -129,7 +132,7 @@ def train_tree(data,
         except:
             None
         _,_ = _train_parentnode(data, labels_train, tree[0], n_neighbors, 
-                                dynamic_neighbors, distkNN)
+                                dynamic_neighbors, distkNN, gpu=gpu)
     else:
         for n in tree[0].descendants:
             _ = _train_node(data, labels, n, classifier, dimred, numgenes)
@@ -175,7 +178,7 @@ def _train_node(data, labels, n, classifier, dimred, numgenes):
         
     return group
 
-def _train_parentnode(data, labels, n, n_neighbors, dynamic_neighbors, distkNN):
+def _train_parentnode(data, labels, n, n_neighbors, dynamic_neighbors, distkNN, gpu=None):
     '''Train a knn classifier. In contrast to the linear svm and oc svm, this 
         is trained for each parent node instead of each child node
         
@@ -187,6 +190,7 @@ def _train_parentnode(data, labels, n, n_neighbors, dynamic_neighbors, distkNN):
         classifier: which classifier to use
         dimred: dimensionality reduction
         numgenes: number of genes in the training data
+        gpu: GPU index to use for the Faiss library (only used when classifier='knn')
         
         Return
         ------
@@ -203,7 +207,7 @@ def _train_parentnode(data, labels, n, n_neighbors, dynamic_neighbors, distkNN):
         for j in n.descendants:
             group_new, labels_new = _train_parentnode(data, labels, j, 
                                                       n_neighbors, dynamic_neighbors,
-                                                      distkNN)
+                                                      distkNN, gpu=gpu)
             group[np.where(group_new == 1)[0]] = 1
             labels[np.where(group_new == 1)[0]] = labels_new[np.where(group_new == 1)[0]]
         if n.name != None:
@@ -211,7 +215,7 @@ def _train_parentnode(data, labels, n, n_neighbors, dynamic_neighbors, distkNN):
             if len(n.descendants) == 1:
                 group[np.squeeze(np.isin(labels, n.name))] = 1
             # train_knn 
-            _train_knn(data,labels,group,n,n_neighbors,dynamic_neighbors,distkNN)
+            _train_knn(data,labels,group,n,n_neighbors,dynamic_neighbors,distkNN,gpu=gpu)
             # rename all group == 1 to node.name
             group[np.squeeze(np.isin(labels, n.name))] = 1
             labels[group==1] = n.name[0]
@@ -271,7 +275,7 @@ def _train_svm(data, labels, group, n):
     n.set_classifier(clf) #save classifier to the node
     
 
-def _train_knn(data, labels, group, n, n_neighbors, dynamic_neighbors, distkNN):
+def _train_knn(data, labels, group, n, n_neighbors, dynamic_neighbors, distkNN, gpu=None):
     '''Train a linear svm and attach to the node
     
         Parameters:
@@ -300,7 +304,7 @@ def _train_knn(data, labels, group, n, n_neighbors, dynamic_neighbors, distkNN):
     try:
         import faiss
         from .faissKNeighbors import FaissKNeighbors 
-        clf = FaissKNeighbors(k=k)
+        clf = FaissKNeighbors(k=k, gpu=gpu)
         clf.fit(data_knn, labels_knn)
         #print('Using FAISS library')
 

--- a/scHPL/train.py
+++ b/scHPL/train.py
@@ -35,7 +35,8 @@ def train_tree(data,
                n_neighbors: int = 50,
                dynamic_neighbors: bool = True,
                distkNN: int = 99,
-               gpu: Optional[int] = None):
+               gpu: Optional[int] = None,
+               compress: bool = False):
     '''Train a hierarchical classifier. 
     
         Parameters
@@ -69,6 +70,9 @@ def train_tree(data,
             set
         gpu: int | None = None
             GPU index to use for the Faiss library (only used when classifier='knn')
+        compress: bool = False
+            If 'True', the Faiss library will use a compressed index for the kNN 
+            classifier.
 
         
         Returns
@@ -132,7 +136,7 @@ def train_tree(data,
         except:
             None
         _,_ = _train_parentnode(data, labels_train, tree[0], n_neighbors, 
-                                dynamic_neighbors, distkNN, gpu=gpu)
+                                dynamic_neighbors, distkNN, gpu=gpu, compress=compress)
     else:
         for n in tree[0].descendants:
             _ = _train_node(data, labels, n, classifier, dimred, numgenes)
@@ -178,7 +182,7 @@ def _train_node(data, labels, n, classifier, dimred, numgenes):
         
     return group
 
-def _train_parentnode(data, labels, n, n_neighbors, dynamic_neighbors, distkNN, gpu=None):
+def _train_parentnode(data, labels, n, n_neighbors, dynamic_neighbors, distkNN, gpu=None, compress=False):
     '''Train a knn classifier. In contrast to the linear svm and oc svm, this 
         is trained for each parent node instead of each child node
         
@@ -191,6 +195,7 @@ def _train_parentnode(data, labels, n, n_neighbors, dynamic_neighbors, distkNN, 
         dimred: dimensionality reduction
         numgenes: number of genes in the training data
         gpu: GPU index to use for the Faiss library (only used when classifier='knn')
+        compress: If 'True', the Faiss library will use a compressed index for the kNN classifier.
         
         Return
         ------
@@ -207,7 +212,7 @@ def _train_parentnode(data, labels, n, n_neighbors, dynamic_neighbors, distkNN, 
         for j in n.descendants:
             group_new, labels_new = _train_parentnode(data, labels, j, 
                                                       n_neighbors, dynamic_neighbors,
-                                                      distkNN, gpu=gpu)
+                                                      distkNN, gpu=gpu, compress=compress)
             group[np.where(group_new == 1)[0]] = 1
             labels[np.where(group_new == 1)[0]] = labels_new[np.where(group_new == 1)[0]]
         if n.name != None:
@@ -215,7 +220,7 @@ def _train_parentnode(data, labels, n, n_neighbors, dynamic_neighbors, distkNN, 
             if len(n.descendants) == 1:
                 group[np.squeeze(np.isin(labels, n.name))] = 1
             # train_knn 
-            _train_knn(data,labels,group,n,n_neighbors,dynamic_neighbors,distkNN,gpu=gpu)
+            _train_knn(data,labels,group,n,n_neighbors,dynamic_neighbors,distkNN,gpu=gpu, compress=compress)
             # rename all group == 1 to node.name
             group[np.squeeze(np.isin(labels, n.name))] = 1
             labels[group==1] = n.name[0]
@@ -275,7 +280,7 @@ def _train_svm(data, labels, group, n):
     n.set_classifier(clf) #save classifier to the node
     
 
-def _train_knn(data, labels, group, n, n_neighbors, dynamic_neighbors, distkNN, gpu=None):
+def _train_knn(data, labels, group, n, n_neighbors, dynamic_neighbors, distkNN, gpu=None, compress=False):
     '''Train a linear svm and attach to the node
     
         Parameters:
@@ -304,7 +309,7 @@ def _train_knn(data, labels, group, n, n_neighbors, dynamic_neighbors, distkNN, 
     try:
         import faiss
         from .faissKNeighbors import FaissKNeighbors 
-        clf = FaissKNeighbors(k=k, gpu=gpu)
+        clf = FaissKNeighbors(k=k, gpu=gpu, compress=compress)
         clf.fit(data_knn, labels_knn)
         #print('Using FAISS library')
 

--- a/scHPL/train.py
+++ b/scHPL/train.py
@@ -19,9 +19,9 @@ from .utils import TreeNode
 import copy as cp
 
 try:
-    from typing import Literal
+    from typing import Literal, Optional
 except ImportError:
-    from typing_extensions import Literal
+    from typing_extensions import Literal, Optional
 
 
 @ignore_warnings(category=ConvergenceWarning)
@@ -35,7 +35,7 @@ def train_tree(data,
                n_neighbors: int = 50,
                dynamic_neighbors: bool = True,
                distkNN: int = 99,
-               gpu=None):
+               gpu: Optional[int] = None):
     '''Train a hierarchical classifier. 
     
         Parameters

--- a/scHPL/utils.py
+++ b/scHPL/utils.py
@@ -371,20 +371,15 @@ def _print_node(node, hor, ver_steps, fig, new_nodes):
     x, y = ([np.max([0.05, hor-0.045]), hor], [ver, ver])
     line = mlines.Line2D(x,y, lw=1)
     fig.add_artist(line)
-    
-    # Add textbox
-    if np.isin(node.name[0], new_nodes):
-        txt = r"$\bf{" + node.name[0] + "}$"
-    else:
-        txt = node.name[0]
-    
-    for n in node.name:
-        if(n != node.name[0]):
-            if np.isin(n, new_nodes):
-                txt = txt + ' & ' + r"$\bf{" + n + "}$"
-            else:
-                txt = txt + ' & ' + n
-                
+
+    def format_node(name):
+        if np.isin(name, new_nodes):
+            return r"$\bf{" + name.replace("_", "\_") + "}$"
+        else:
+            return name
+
+    txt = " & ".join([format_node(n) for n in node.name])
+
     fig.text(hor,ver, txt, size=10,
              ha = 'left', va='center',
              bbox = dict(boxstyle='round', fc='w', ec='k'))

--- a/scHPL/utils.py
+++ b/scHPL/utils.py
@@ -53,7 +53,7 @@ class TreeNode(Node):
         """
         Add a classifier to the node.
         """
-        self.classifier = copy.deepcopy(classifier)
+        self.classifier = classifier
     
     def get_classifier(self):
         return self.classifier

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
         "numpy>=1.19.2",
         "scipy>=1.5.2",
         "scikit-learn>=0.23.2",
-        "pandas>=1.1.2,<=2.2.2",
+        "pandas>=1.1.2,<2.0.0",
         "newick~=1.0.0",
         "anndata>=0.7.4",
         "matplotlib>=3.3.1",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
         "numpy>=1.19.2",
         "scipy>=1.5.2",
         "scikit-learn>=0.23.2",
-        "pandas>=1.1.2,<2.0.0",
+        "pandas>=1.1.2,<=2.2.2",
         "newick~=1.0.0",
         "anndata>=0.7.4",
         "matplotlib>=3.3.1",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("README.rst", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="scHPL", 
-    version="1.0.4",
+    version="1.0.3",
     author="Lieke Michielsen",
     author_email="l.c.m.michielsen@tudelft.nl",
     description="Hierarchical progressive learning pipeline for single-cell RNA-sequencing datasets",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open("README.rst", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="scHPL", 
-    version="1.0.3",
+    version="1.0.4",
     author="Lieke Michielsen",
     author_email="l.c.m.michielsen@tudelft.nl",
     description="Hierarchical progressive learning pipeline for single-cell RNA-sequencing datasets",


### PR DESCRIPTION
When trying to use the package with FAISS-GPU installed, the GPU was not used automatically and also there was no option for enabling it manually. I added this functionality. 

However, there are some things that would require further discussion:

1. I removed the deep copy of the classifier since the deep copy fails for GPU indices
2. I added an option for disabling the tree printing, since it fails if the GPU is enabled (there is probably an easy fix for this, but I don't know enough about the implementation)